### PR TITLE
Prevent large allocation in XdrString when size is larger than buffer size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/zeldovich/go-rpcgen
 
 go 1.13
+
+require github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/xdr/lib.go
+++ b/xdr/lib.go
@@ -206,10 +206,9 @@ func XdrVarArray(xs *XdrState, maxlen int, v *[]byte) {
 	} else {
 		var szbuf [4]byte
 		xdrRW(xs, szbuf[:])
-		sz32 := binary.BigEndian.Uint32(szbuf[:])
-		sz := int(sz32)
+		sz := int(binary.BigEndian.Uint32(szbuf[:]))
 
-		if (maxlen >= 0 && sz > maxlen) || sz32 < 0 {
+		if maxlen >= 0 && sz > maxlen {
 			xs.SetError("var array too large")
 			return
 		}
@@ -258,8 +257,7 @@ func XdrString(xs *XdrState, maxlen int, v *string) {
 		sz := int(binary.BigEndian.Uint32(szbuf[:]))
 		// don't try decoding more than the buffer contains
 		if sz > len(xs.buf) {
-			xs.err = fmt.Errorf("string length %d greater than buffer size %d",
-				sz, len(xs.buf))
+			xs.err = fmt.Errorf("Not enough bytes for string: wanted %d, have %d", sz, len(xs.buf))
 			return
 		}
 

--- a/xdr/xdr_test.go
+++ b/xdr/xdr_test.go
@@ -1,0 +1,38 @@
+package xdr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXdrString(t *testing.T) {
+	xw := MakeWriter(nil)
+	s := "hello"
+	XdrString(xw, 100, &s)
+	assert.NoError(t, xw.Error())
+	buf := xw.WriteBuf()
+
+	xr := MakeReader(buf)
+	var newString string
+	XdrString(xr, 100, &newString)
+	assert.NoError(t, xr.Error())
+	assert.Equal(t, s, newString)
+}
+
+func TestLargeStringLength(t *testing.T) {
+	xw := MakeWriter(nil)
+	s := "hello world"
+	XdrString(xw, 100, &s)
+	buf := xw.WriteBuf()
+	// cut off the actual string (but leave the length as len(s))
+	//
+	// 6 is enough for the length prefix (4 bytes) and a little bit for the
+	// string
+	buf = buf[:6]
+
+	xr := MakeReader(buf)
+	var newString string
+	XdrString(xr, 100, &newString)
+	assert.Error(t, xr.Error())
+}

--- a/xdr/xdr_test.go
+++ b/xdr/xdr_test.go
@@ -36,3 +36,30 @@ func TestLargeStringLength(t *testing.T) {
 	XdrString(xr, 100, &newString)
 	assert.Error(t, xr.Error())
 }
+
+func TestXdrVarArray(t *testing.T) {
+	xw := MakeWriter(nil)
+	v := []byte{1, 2, 3}
+	XdrVarArray(xw, 100, &v)
+	assert.NoError(t, xw.Error())
+	buf := xw.WriteBuf()
+
+	xr := MakeReader(buf)
+	var newArray []byte
+	XdrVarArray(xr, 100, &newArray)
+	assert.NoError(t, xr.Error())
+	assert.Equal(t, v, newArray)
+}
+
+func TestLargeVarArrayLength(t *testing.T) {
+	xw := MakeWriter(nil)
+	v := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	XdrVarArray(xw, 100, &v)
+	buf := xw.WriteBuf()
+	buf = buf[:6]
+
+	xr := MakeReader(buf)
+	var newArray []byte
+	XdrVarArray(xr, 100, &newArray)
+	assert.Error(t, xr.Error())
+}


### PR DESCRIPTION
XdrString allocates a byte slice based on the size prefix, without checking it against the actual buffer size. This PR makes the XdrString behavior match XdrVarArray, throwing an error if the size exceeds the buffer size for a string.